### PR TITLE
Fail if user could not be deleted

### DIFF
--- a/oracle_user
+++ b/oracle_user
@@ -466,6 +466,8 @@ def main():
             if drop_user(module, msg, cursor, schema):
                 msg = 'The schema (%s) has been dropped successfully' % schema
                 module.exit_json(msg=msg, changed=True)
+            else:
+                module.fail_json(msg=msg[0], changed=False)
         else:
             module.exit_json(msg='The schema (%s) doesn\'t exist' % schema, changed=False)
 


### PR DESCRIPTION
If the Oracle User could not be deleted (for example because there are still open connections), the module falsely gives a Success-Message. With this PR the Error Message from Oracle will be propagated properly.